### PR TITLE
Add bc to dependency list

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Standards-Version: 3.9.3
 Package: sleepproxyclient
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, python-dnspython, python-argparse,
- python-netifaces, python-avahi, pm-utils
+ python-netifaces, python-avahi, pm-utils, bc
 Description: mDNS Sleep Proxy Client implementation.
  sleepproxyclient is a Linux implementation for Wake On Demand.
  All announced avahi-services will be registered to all available


### PR DESCRIPTION
checkSleep.sh uses bc, but the debian package does not declare that dependency.

This caused me to have to install bc on my fileserver which is set up very minimally.
